### PR TITLE
Add metadata to run_info in the report

### DIFF
--- a/unshard/migrate_runs.go
+++ b/unshard/migrate_runs.go
@@ -275,7 +275,7 @@ func main() {
 				continue
 			}
 			productID := fmt.Sprintf("%s-%s-%s", testRun.BrowserName, testRun.BrowserVersion, testRun.OSName)
-			if testRun.OSVersion != "" {
+			if testRun.OSVersion != "" && testRun.OSVersion != "*" {
 				productID += "-" + testRun.OSVersion
 			}
 			bucketDir := fmt.Sprintf("%s/%s", hash, productID)
@@ -338,6 +338,8 @@ func main() {
 						ProductAtRevision: testRun.ProductAtRevision,
 					},
 				}
+				// Legacy runs don't have FullRevisionHash in Datastore.
+				report.RunInfo.FullRevisionHash = hash
 
 				log.Printf("Writing consolidated results to %s/%s", *outputGcsBucket, remoteReportPath)
 				if err = writeJSON(ctx, outputBucket, remoteReportPath, report); err != nil {

--- a/unshard/migrate_runs.go
+++ b/unshard/migrate_runs.go
@@ -326,11 +326,8 @@ func main() {
 				}
 				report := metrics.TestResultsReport{
 					Results: results,
-					RunInfo: metrics.TestResultsReport{
-						Product:        testRun.BrowserName,
-						BrowserVersion: testRun.BrowserVersion,
-						OS:             testRun.OSName,
-						OSVersion:      testRun.OSVersion,
+					RunInfo: metrics.RunInfo{
+						ProductAtRevision: testRun.ProductAtRevision,
 					},
 				}
 


### PR DESCRIPTION
This PR requires https://github.com/web-platform-tests/results-analysis/pull/42. It will

1. Fix #1 ; besides, the script will no longer upload `migration.log` to GCS because 1) the log is not very useful for users and 2) it'll make the transition easier (see below).
2. Switch to dash-separated path schemas (part of #4 , but for the newly arrived runs)

As for the runs that have been unsharded, the transition will be done by #3 as follows:

1. Scan TestRuns in Datastore.
2. For each test run with `RawResultsURL`, check if there's a `migration.log` next to the raw report. If not, skip this run.
3. Download the raw report, add metadata to its `run_info` field, and upload the report to the new dash-separated URL.
4. Modify the `RawResultsURL` of this run in Datastore.