### PR TITLE
Add a script to backfill TimeStart from CreatedAt

### DIFF
--- a/add_time_start/add_time_start.go
+++ b/add_time_start/add_time_start.go
@@ -1,0 +1,75 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+
+	"cloud.google.com/go/datastore"
+	"google.golang.org/api/iterator"
+
+	"github.com/web-platform-tests/wpt.fyi/shared"
+)
+
+var (
+	projectID = flag.String("project", "wptdashboard-staging", "Google Cloud project")
+)
+
+type conditionUnsatisfied struct{}
+
+func (e conditionUnsatisfied) Error() string {
+	return "Condition not satisfied"
+}
+
+func condition(run *shared.TestRun) bool {
+	return run.TimeStart.IsZero()
+}
+
+func operation(tx *datastore.Transaction, key *datastore.Key, run *shared.TestRun) error {
+	run.TimeStart = run.CreatedAt
+	_, err := tx.Put(key, run)
+	return err
+}
+
+func main() {
+	flag.Parse()
+
+	ctx := context.Background()
+
+	dsClient, err := datastore.NewClient(ctx, *projectID)
+	if err != nil {
+		panic(err)
+	}
+
+	query := datastore.NewQuery("TestRun").KeysOnly()
+
+	for t := dsClient.Run(ctx, query); ; {
+		key, err := t.Next(nil)
+		if err == iterator.Done {
+			break
+		}
+		if err != nil {
+			panic(err)
+		}
+		var run shared.TestRun
+		_, err = dsClient.RunInTransaction(ctx, func(tx *datastore.Transaction) error {
+			err := tx.Get(key, &run)
+			if err != nil {
+				return err
+			}
+			if condition(&run) {
+				return operation(tx, key, &run)
+			}
+			return conditionUnsatisfied{}
+		})
+		if err != nil {
+			_, ok := err.(conditionUnsatisfied)
+			if !ok {
+				panic(err)
+			} else {
+				continue
+			}
+		}
+		fmt.Printf("Proccessed TestRun %s (%s %s)\n", key.String(), run.BrowserName, run.BrowserVersion)
+	}
+}


### PR DESCRIPTION
I'm planning to backfill the `TimeStart` field from the exciting `CreatedAt` for all test runs that don't have this field. This has to be done before changing the sort key from `CreatedAt` to `TimeStart`. I'll run this script in staging first and a send a PR to change the sort key in staging. And before the next prod release, we'll need to run this script again in prod.

The code is pretty much the same as the well-tested tagger, so it's more about reviewing the procedure above than reviewing the code.