### PR TITLE
Create interface instead of copy-pasting

### DIFF
--- a/processor/migrate.go
+++ b/processor/migrate.go
@@ -1,0 +1,71 @@
+package processor
+
+import (
+	"context"
+	"flag"
+	"fmt"
+
+	"cloud.google.com/go/datastore"
+	"github.com/web-platform-tests/wpt.fyi/shared"
+	"google.golang.org/api/iterator"
+)
+
+var (
+	projectID = flag.String("project", "wptdashboard-staging", "Google Cloud project")
+)
+
+type ConditionUnsatisfied struct{}
+
+func (e ConditionUnsatisfied) Error() string {
+	return "Condition not satisfied"
+}
+
+// MigrateData handles all the loading and transactions across the full
+// datastore. It should be called from a main(), e.g.
+//
+// func main() {
+//   p := experimentalLabeller{}
+//   processor.MigrateData(p)
+// }
+func MigrateData(runsProcessor Runs) {
+	flag.Parse()
+
+	ctx := context.Background()
+
+	dsClient, err := datastore.NewClient(ctx, *projectID)
+	if err != nil {
+		panic(err)
+	}
+
+	query := datastore.NewQuery("TestRun").KeysOnly()
+
+	for t := dsClient.Run(ctx, query); ; {
+		key, err := t.Next(nil)
+		if err == iterator.Done {
+			break
+		}
+		if err != nil {
+			panic(err)
+		}
+		var run shared.TestRun
+		_, err = dsClient.RunInTransaction(ctx, func(tx *datastore.Transaction) error {
+			err := tx.Get(key, &run)
+			if err != nil {
+				return err
+			}
+			if runsProcessor.ShouldProcessRun(&run) {
+				return runsProcessor.ProcessRun(tx, key, &run)
+			}
+			return ConditionUnsatisfied{}
+		})
+		if err != nil {
+			_, ok := err.(ConditionUnsatisfied)
+			if !ok {
+				panic(err)
+			} else {
+				continue
+			}
+		}
+		fmt.Printf("Processed TestRun %s (%s %s)\n", key.String(), run.BrowserName, run.BrowserVersion)
+	}
+}

--- a/processor/runs.go
+++ b/processor/runs.go
@@ -1,0 +1,12 @@
+package processor
+
+import (
+	"cloud.google.com/go/datastore"
+	"github.com/web-platform-tests/wpt.fyi/shared"
+)
+
+// Runs is an interface for processors of TestRun entities.
+type Runs interface {
+	ShouldProcessRun(run *shared.TestRun) bool
+	ProcessRun(tx *datastore.Transaction, key *datastore.Key, run *shared.TestRun) error
+}

--- a/tagger/browser_name.go
+++ b/tagger/browser_name.go
@@ -1,28 +1,18 @@
 package main
 
 import (
-	"context"
-	"flag"
-	"fmt"
 	"strings"
 
 	"cloud.google.com/go/datastore"
-	"google.golang.org/api/iterator"
 
+	"github.com/web-platform-tests/data-migration/processor"
 	"github.com/web-platform-tests/wpt.fyi/shared"
 )
 
-var (
-	projectID = flag.String("project", "wptdashboard-staging", "Google Cloud project")
-)
+// browserNameLabeller labels a run with its browser name.
+type browserNameLabeller struct{}
 
-type conditionUnsatisfied struct{}
-
-func (e conditionUnsatisfied) Error() string {
-	return "Condition not satisfied"
-}
-
-func condition(run *shared.TestRun) bool {
+func (b browserNameLabeller) ShouldProcessRun(run *shared.TestRun) bool {
 	if !shared.IsBrowserName(run.BrowserName) {
 		return false
 	}
@@ -34,51 +24,12 @@ func condition(run *shared.TestRun) bool {
 	return true
 }
 
-func operation(tx *datastore.Transaction, key *datastore.Key, run *shared.TestRun) error {
+func (b browserNameLabeller) ProcessRun(tx *datastore.Transaction, key *datastore.Key, run *shared.TestRun) error {
 	run.Labels = append(run.Labels, strings.TrimSuffix(run.BrowserName, "-experimental"))
 	_, err := tx.Put(key, run)
 	return err
 }
 
 func main() {
-	flag.Parse()
-
-	ctx := context.Background()
-
-	dsClient, err := datastore.NewClient(ctx, *projectID)
-	if err != nil {
-		panic(err)
-	}
-
-	query := datastore.NewQuery("TestRun").KeysOnly()
-
-	for t := dsClient.Run(ctx, query); ; {
-		key, err := t.Next(nil)
-		if err == iterator.Done {
-			break
-		}
-		if err != nil {
-			panic(err)
-		}
-		var run shared.TestRun
-		_, err = dsClient.RunInTransaction(ctx, func(tx *datastore.Transaction) error {
-			err := tx.Get(key, &run)
-			if err != nil {
-				return err
-			}
-			if condition(&run) {
-				return operation(tx, key, &run)
-			}
-			return conditionUnsatisfied{}
-		})
-		if err != nil {
-			_, ok := err.(conditionUnsatisfied)
-			if !ok {
-				panic(err)
-			} else {
-				continue
-			}
-		}
-		fmt.Printf("Proccessed TestRun %s (%s %s)\n", key.String(), run.BrowserName, run.BrowserVersion)
-	}
+	processor.MigrateData(browserNameLabeller{})
 }

--- a/tagger/experimental.go
+++ b/tagger/experimental.go
@@ -1,29 +1,18 @@
 package main
 
 import (
-	"context"
-	"flag"
-	"fmt"
 	"strings"
 
 	"cloud.google.com/go/datastore"
 	mapset "github.com/deckarep/golang-set"
-	"google.golang.org/api/iterator"
 
+	"github.com/web-platform-tests/data-migration/processor"
 	"github.com/web-platform-tests/wpt.fyi/shared"
 )
 
-var (
-	projectID = flag.String("project", "wptdashboard-staging", "Google Cloud project")
-)
+type experimentalLabeller struct{}
 
-type conditionUnsatisfied struct{}
-
-func (e conditionUnsatisfied) Error() string {
-	return "Condition not satisfied"
-}
-
-func condition(run *shared.TestRun) bool {
+func (e experimentalLabeller) ShouldProcessRun(run *shared.TestRun) bool {
 	if !shared.IsBrowserName(run.BrowserName) {
 		return false
 	}
@@ -36,7 +25,7 @@ func condition(run *shared.TestRun) bool {
 	return false
 }
 
-func operation(tx *datastore.Transaction, key *datastore.Key, run *shared.TestRun) error {
+func (e experimentalLabeller) ProcessRun(tx *datastore.Transaction, key *datastore.Key, run *shared.TestRun) error {
 	labels := mapset.NewSet()
 	for _, label := range run.Labels {
 		labels.Add(label)
@@ -52,44 +41,5 @@ func operation(tx *datastore.Transaction, key *datastore.Key, run *shared.TestRu
 }
 
 func main() {
-	flag.Parse()
-
-	ctx := context.Background()
-
-	dsClient, err := datastore.NewClient(ctx, *projectID)
-	if err != nil {
-		panic(err)
-	}
-
-	query := datastore.NewQuery("TestRun").KeysOnly()
-
-	for t := dsClient.Run(ctx, query); ; {
-		key, err := t.Next(nil)
-		if err == iterator.Done {
-			break
-		}
-		if err != nil {
-			panic(err)
-		}
-		var run shared.TestRun
-		_, err = dsClient.RunInTransaction(ctx, func(tx *datastore.Transaction) error {
-			err := tx.Get(key, &run)
-			if err != nil {
-				return err
-			}
-			if condition(&run) {
-				return operation(tx, key, &run)
-			}
-			return conditionUnsatisfied{}
-		})
-		if err != nil {
-			_, ok := err.(conditionUnsatisfied)
-			if !ok {
-				panic(err)
-			} else {
-				continue
-			}
-		}
-		fmt.Printf("Proccessed TestRun %s (%s %s)\n", key.String(), run.BrowserName, run.BrowserVersion)
-	}
+	processor.MigrateData(experimentalLabeller{})
 }

--- a/tagger/master.go
+++ b/tagger/master.go
@@ -1,9 +1,7 @@
 package main
 
 import (
-	"context"
-	"flag"
-	"fmt"
+	"log"
 	"os"
 	"os/exec"
 	"path"
@@ -12,82 +10,41 @@ import (
 	"github.com/deckarep/golang-set"
 
 	"cloud.google.com/go/datastore"
-	"google.golang.org/api/iterator"
 
+	"github.com/web-platform-tests/data-migration/processor"
 	"github.com/web-platform-tests/wpt.fyi/shared"
 )
 
-var (
-	projectID = flag.String("project", "wptdashboard-staging", "Google Cloud project")
-	allSHAs   = mapset.NewSet()
-)
-
-type conditionUnsatisfied struct{}
-
-func (e conditionUnsatisfied) Error() string {
-	return "Condition not satisfied"
+type masterLabeller struct {
+	AllMasterSHAs mapset.Set
 }
 
-func condition(run *shared.TestRun) bool {
-	return !run.LabelsSet().Contains("master") && allSHAs.Contains(run.Revision)
+func (m masterLabeller) ShouldProcessRun(run *shared.TestRun) bool {
+	return !run.LabelsSet().Contains("master") && m.AllMasterSHAs.Contains(run.Revision)
 }
 
-func operation(tx *datastore.Transaction, key *datastore.Key, run *shared.TestRun) error {
+func (m masterLabeller) ProcessRun(tx *datastore.Transaction, key *datastore.Key, run *shared.TestRun) error {
 	run.Labels = append(run.Labels, "master")
 	_, err := tx.Put(key, run)
 	return err
 }
 
 func main() {
-	flag.Parse()
-
-	ctx := context.Background()
-
-	dsClient, err := datastore.NewClient(ctx, *projectID)
-	if err != nil {
-		panic(err)
-	}
-
 	cmd := exec.Command("git", "rev-list", "origin/master")
 	dir, err := os.Getwd()
 	cmd.Dir = path.Join(dir, "../wpt")
 	bytes, err := cmd.Output()
+	if err != nil {
+		log.Fatalf("Failed to scrape revisions: %s", err.Error())
+	}
+	allSHAs := mapset.NewSet()
 	for _, hash := range strings.Split(string(bytes), "\n") {
 		if len(hash) > 9 {
 			allSHAs.Add(hash)
 			allSHAs.Add(hash[:10])
 		}
 	}
-
-	query := datastore.NewQuery("TestRun").KeysOnly()
-
-	for t := dsClient.Run(ctx, query); ; {
-		key, err := t.Next(nil)
-		if err == iterator.Done {
-			break
-		}
-		if err != nil {
-			panic(err)
-		}
-		var run shared.TestRun
-		_, err = dsClient.RunInTransaction(ctx, func(tx *datastore.Transaction) error {
-			err := tx.Get(key, &run)
-			if err != nil {
-				return err
-			}
-			if condition(&run) {
-				return operation(tx, key, &run)
-			}
-			return conditionUnsatisfied{}
-		})
-		if err != nil {
-			_, ok := err.(conditionUnsatisfied)
-			if !ok {
-				panic(err)
-			} else {
-				continue
-			}
-		}
-		fmt.Printf("Processed TestRun %s (%s %s)\n", key.String(), run.BrowserName, run.BrowserVersion)
-	}
+	processor.MigrateData(masterLabeller{
+		AllMasterSHAs: allSHAs,
+	})
 }

--- a/tagger/stable.go
+++ b/tagger/stable.go
@@ -1,29 +1,18 @@
 package main
 
 import (
-	"context"
-	"flag"
-	"fmt"
 	"strings"
 
 	"cloud.google.com/go/datastore"
 	mapset "github.com/deckarep/golang-set"
-	"google.golang.org/api/iterator"
 
+	"github.com/web-platform-tests/data-migration/processor"
 	"github.com/web-platform-tests/wpt.fyi/shared"
 )
 
-var (
-	projectID = flag.String("project", "wptdashboard-staging", "Google Cloud project")
-)
+type stableLabeller struct{}
 
-type conditionUnsatisfied struct{}
-
-func (e conditionUnsatisfied) Error() string {
-	return "Condition not satisfied"
-}
-
-func condition(run *shared.TestRun) bool {
+func (e stableLabeller) ShouldProcessRun(run *shared.TestRun) bool {
 	if !shared.IsBrowserName(run.BrowserName) {
 		return false
 	}
@@ -36,7 +25,7 @@ func condition(run *shared.TestRun) bool {
 	return true
 }
 
-func operation(tx *datastore.Transaction, key *datastore.Key, run *shared.TestRun) error {
+func (e stableLabeller) ProcessRun(tx *datastore.Transaction, key *datastore.Key, run *shared.TestRun) error {
 	labels := mapset.NewSet()
 	for _, label := range run.Labels {
 		labels.Add(label)
@@ -52,44 +41,5 @@ func operation(tx *datastore.Transaction, key *datastore.Key, run *shared.TestRu
 }
 
 func main() {
-	flag.Parse()
-
-	ctx := context.Background()
-
-	dsClient, err := datastore.NewClient(ctx, *projectID)
-	if err != nil {
-		panic(err)
-	}
-
-	query := datastore.NewQuery("TestRun").KeysOnly()
-
-	for t := dsClient.Run(ctx, query); ; {
-		key, err := t.Next(nil)
-		if err == iterator.Done {
-			break
-		}
-		if err != nil {
-			panic(err)
-		}
-		var run shared.TestRun
-		_, err = dsClient.RunInTransaction(ctx, func(tx *datastore.Transaction) error {
-			err := tx.Get(key, &run)
-			if err != nil {
-				return err
-			}
-			if condition(&run) {
-				return operation(tx, key, &run)
-			}
-			return conditionUnsatisfied{}
-		})
-		if err != nil {
-			_, ok := err.(conditionUnsatisfied)
-			if !ok {
-				panic(err)
-			} else {
-				continue
-			}
-		}
-		fmt.Printf("Proccessed TestRun %s (%s %s)\n", key.String(), run.BrowserName, run.BrowserVersion)
-	}
+	processor.MigrateData(stableLabeller{})
 }


### PR DESCRIPTION
Creates an explicit interface for the code-paths that were generically named. 